### PR TITLE
Update deprecated function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy", "scipy", "matplotlib", "pandas", "dask", "networkx"]
+dependencies = ["numpy", "scipy", "matplotlib", "pandas", "dask", "networkx>=3.2.1"]
 dynamic = ["version"]
 
 [project.urls]

--- a/src/track_linearization/core.py
+++ b/src/track_linearization/core.py
@@ -149,7 +149,7 @@ def route_distance(candidates_t_1, candidates_t, track_graph):
 
     # calculate path distance
     path_distance = scipy.sparse.csgraph.dijkstra(
-        nx.to_scipy_sparse_matrix(track_graph, weight="distance")
+        nx.to_scipy_sparse_array(track_graph, weight="distance")
     )
     n_total_nodes = len(track_graph.nodes)
     node_ind = np.arange(n_total_nodes)


### PR DESCRIPTION
I created a new enviornment using the instructions on the documentation, and it outputted an attribute error while running it.
`AttributeError: module 'networkx' has no attribute 'to_scipy_sparse_matrix`
My environment has Networkx (3.42), and I followed recommendations to change to_scipy_sparse_matrix to to_scipy_sparse_array to fix the error. I also updated the toml file to be compatible with this change. 